### PR TITLE
Fix panel background

### DIFF
--- a/operaldi.css
+++ b/operaldi.css
@@ -162,6 +162,10 @@ div#main.right #panels-container {
     min-width: 44px;
 }
 
+.panel {
+    background-color: var(--colorBgAlphaBlur);
+}
+
 #panels-container { /*FIXING SIDEBAR PART 3 */
     background-color: transparent;
     margin-right: 5px;

--- a/operaldi.css
+++ b/operaldi.css
@@ -163,7 +163,7 @@ div#main.right #panels-container {
 }
 
 .panel {
-    background-color: var(--colorBgAlphaBlur);
+    background-color: color-mix(in srgb, var(--colorBg), var(--lessTransparent));
 }
 
 #panels-container { /*FIXING SIDEBAR PART 3 */


### PR DESCRIPTION
Hey, first of all, thanks a lot for this css, it's great :)

It turns out however that panels are fully transparent on my side, meaning I can't read anything if the underlying webpage is close to foreground color:
<img width="2524" height="1494" alt="2025-09-03-At-10h24m19s" src="https://github.com/user-attachments/assets/66c6bf36-fa2f-4980-851f-7d0d989930c6" />

Here is a simple fix :)